### PR TITLE
The sizes of downloaded files are 0 when overwrite=False

### DIFF
--- a/CEDA_download.py
+++ b/CEDA_download.py
@@ -103,15 +103,16 @@ def download_batch(datasets,
                 base_fn = os.path.basename(fn)
                 logging.info("      " + os.path.basename(base_fn))
                 save_fn = os.path.join(save_path, base_fn)
-                write_cb = open(save_fn, 'wb').write
 
                 if os.path.exists(save_fn):
                     if overwrite:
+                        write_cb = open(save_fn, 'wb').write
                         logging.info("      Downloading/writing to " + save_fn)
                         ftp.retrbinary("RETR " + fn, write_cb)
                     else:
                         logging.info("      File exists; skipping " + save_fn)
                 else:
+                    write_cb = open(save_fn, 'wb').write
                     logging.info("      Downloading/writing to " + save_fn)
                     ftp.retrbinary("RETR " + fn, write_cb)
 


### PR DESCRIPTION
Hi Daniel,
I think `write_cb = open(save_fn, 'wb').write` will create the non-existent files, which means that `os.path.exists(save_fn)` will always be `True` in the next if statements. Therefore if `overwrite=False`, the new files will remain empty without being written into any data.
